### PR TITLE
Add agent documentation and conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,9 @@
+<!-- AI_AGENT_GUIDANCE: This file provides AI agents with instructions on interacting with this codebase. -->
+
 # AGENTS.md
 
-This file defines how AI agents (such as Codex, Copilot Agents, or Continue) should interact with this Ansible project. It provides an overview of roles, expected variables, and project conventions to ensure intelligent modifications align with the intended structure and behavior.
+## Introduction
+This repository uses Ansible to configure personal and work computers. AI agents should consult this guide before modifying the codebase. It explains roles, variables and conventions so changes remain consistent.
 
 ---
 
@@ -99,3 +102,43 @@ The project is in a clean state post-refactor. Agents should:
 ## ✍️ Maintainer Note
 
 This repository is actively used to manage a mix of personal and work systems. AI agents should assume that consistency, readability, and predictability are more important than overly clever automation.
+
+---
+
+## Project Structure
+- `playbooks/` contains entry point playbooks such as `site.yml`.
+- `roles/` holds Ansible roles (`software`, `flatpak`, `gnome_setup`, `m3db_client`, `xdg_dirs`).
+- `inventory/` defines host groups in `hosts.yml`.
+- `group_vars/` stores group variable files.
+- `tests/` contains example playbook tests.
+- `doc/` holds assorted notes.
+
+## Build & Run
+Development typically uses a Python virtual environment:
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt
+ansible-galaxy collection install -r requirements.yml
+```
+Validate and execute playbooks:
+```bash
+ansible-lint
+yamllint .
+ansible-playbook playbooks/site.yml --syntax-check
+ansible-playbook tests/test_all.yml --check -i inventory/hosts.yml
+cd roles/software && molecule test
+```
+
+## Code Guidelines
+See [CONVENTIONS.md](CONVENTIONS.md) for style and best practices.
+
+## Contribution Workflow
+1. Create a feature branch.
+2. Make focused commits with clear messages.
+3. Open a pull request targeting `main` and describe your changes.
+
+## Related Docs
+- [README.md](README.md)
+- [CONVENTIONS.md](CONVENTIONS.md)
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,20 @@
+# Conventions
+
+This project follows a few simple conventions to keep the Ansible codebase consistent.
+
+## YAML Style
+- Use two spaces for indentation.
+- Keys and variables use `snake_case`.
+- Boolean values should be `true`/`false` rather than `yes`/`no`.
+
+## Ansible Practices
+- Prefer fully qualified module names (e.g. `ansible.builtin.package`).
+- Use `package` where possible instead of distro-specific modules.
+- Use `loop` instead of deprecated `with_items`.
+- Keep tasks idempotent and guarded with `when:` conditions.
+
+## Linting and Tests
+- Run `ansible-lint` and `yamllint .` before committing.
+- Validate playbooks with `ansible-playbook playbooks/site.yml --syntax-check`.
+- Example tests can be run with `ansible-playbook tests/test_all.yml` and `molecule test` in `roles/software`.
+

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -94,3 +94,7 @@ Execute the test suite:
 ansible-playbook tests/test_all.yml --check -i inventory/hosts.yml
 cd roles/software && molecule test
 ```
+
+## Developer & Agent Docs
+- [AGENTS.md](AGENTS.md)
+- [CONVENTIONS.md](CONVENTIONS.md)


### PR DESCRIPTION
## Summary
- add consolidated agent guidance with contributor workflow
- document repo conventions
- symlink CLAUDE.md and GEMINI.md to AGENTS.md
- link new docs from README

## Testing
- `ansible-lint` *(fails: 110 failures)*
- `yamllint .`
- `ansible-playbook playbooks/site.yml --syntax-check` *(fails: role 'software' not found)*
- `ansible-playbook tests/test_all.yml --check -i inventory/hosts.yml` *(fails: role 'software' not found)*
- `cd roles/software && molecule test` *(fails: DockerException: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_687d1901d3b08329a2ff18098e21c6d9