### PR TITLE
Update Molecule for multi-distro testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ pip install -r requirements-dev.txt
 ansible-galaxy collection install -r requirements.yml
 ```
 
+Ensure Docker is installed and that your user can run containers (typically by
+being in the `docker` group).
+
 Run linting and syntax checks:
 
 ```bash
@@ -92,7 +95,7 @@ Execute the test suite:
 
 ```bash
 ansible-playbook tests/test_all.yml --check -i inventory/hosts.yml
-cd roles/software && molecule test
+cd roles/software && molecule test  # runs against Debian, Fedora, and Arch containers
 ```
 
 ## Developer & Agent Docs

--- a/roles/software/molecule/default/molecule.yml
+++ b/roles/software/molecule/default/molecule.yml
@@ -6,10 +6,23 @@ driver:
   name: docker
 
 platforms:
-  - name: instance
-    image: debian:bullseye
+  - name: debian-bookworm
+    image: geerlingguy/docker-debian12-ansible:latest
     command: /lib/systemd/systemd
     privileged: true
+    pre_build_image: true
+
+  - name: fedora-39
+    image: geerlingguy/docker-fedora39-ansible:latest
+    command: /usr/lib/systemd/systemd
+    privileged: true
+    pre_build_image: true
+
+  - name: archlinux
+    image: geerlingguy/docker-archlinux-ansible:latest
+    command: /usr/lib/systemd/systemd
+    privileged: true
+    pre_build_image: true
 
 provisioner:
   name: ansible


### PR DESCRIPTION
## Summary
- test the software role on multiple distros using Docker
- note Docker requirement and updated command in README

## Testing
- `ansible-lint`
- `yamllint .`
- `ansible-playbook playbooks/site.yml --syntax-check`
- `ansible-playbook tests/test_all.yml --check -i inventory/hosts.yml` *(fails: No package matching)*
- `cd roles/software && molecule test` *(fails: DockerException: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_687d49598f1c832999a4e4d5ecae9909